### PR TITLE
Revert max_comp_streams=6

### DIFF
--- a/rootdir/etc/fstab.qcom
+++ b/rootdir/etc/fstab.qcom
@@ -22,4 +22,4 @@
 /devices/platform/msm_hsusb_host/usb*     auto                   auto    defaults                                                                                        voldmanaged=usb:auto
 
 # ZRAM
-/dev/block/zram0                          none                   swap    defaults                                                                                        zramsize=805306368,max_comp_streams=6
+/dev/block/zram0                          none                   swap    defaults                                                                                        zramsize=805306368,max_comp_streams=4


### PR DESCRIPTION
Was causing more battery drain due to all cores being active